### PR TITLE
Extend support up to Ruby 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,11 @@ workflows:
   version: 2
   rubies:
     jobs:
+      - ruby-3.3
+      - ruby-3.2
+      - ruby-3.1
+      - ruby-3.0
+      - ruby-2.7
       - ruby-2.6
       - ruby-2.5
       - ruby-2.4

--- a/memorb.gemspec
+++ b/memorb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     Memorb makes instance method memoization easy to set up and use.
   TXT
 
-  s.required_ruby_version     = '~> 2.3'
+  s.required_ruby_version     = '>= 2.3', '< 3.4'
   s.required_rubygems_version = '>= 2.5'
 
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Tests passed locally on versions the 3.X versions. I didn't test on 2.7 because it's too old for `ruby-install` now, so we'll see what CI says for that one.